### PR TITLE
Add back dependencies so app can build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,8 @@
     "ember-qunit": "0.2.8",
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.17.1",
-    "picnic": "~3.3.1"
+    "picnic": "~3.3.1",
+    "moment": "~2.9.0",
+    "borrowers-dates": "~0.0.1"
   }
 }


### PR DESCRIPTION
Out of the box, the app will not build because `moment` and `borrowers-dates` are not included in `bower.json`. This pull request this issue.

For the interested: d109bab removed the dependencies (I'm assuming accidentally)
