### PR TITLE
Package 'active-model-adapter' 'v1.13.4' has a bug in the shasum

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "active-model-adapter": "1.13.4",
+    "active-model-adapter": "1.13.5",
     "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "1.13.1",
     "ember-cli-app-version": "0.4.0",


### PR DESCRIPTION
When try `npm install` I get:

```
npm WARN package.json ember-cli-fill-murray@0.3.0 No repository field.
npm ERR! Darwin 15.0.0
npm ERR! argv "/usr/local/Cellar/node/5.0.0/bin/node" "/Users/fguillen/.node/bin/npm" "install"
npm ERR! node v5.0.0
npm ERR! npm  v2.7.3

npm ERR! shasum check failed for /var/folders/zy/2d4tl0wn6514t1wbmt4vh8840000gn/T/npm-45471-4ee58b45/registry.npmjs.org/active-model-adapter/-/active-model-adapter-1.13.4.tgz
npm ERR! Expected: 894bbae414278da6f68229959ee72aff34a669b5
npm ERR! Actual:   23212ae5107f7b7b1c109f72a69cc554eb3b491e
npm ERR! From:     https://registry.npmjs.org/active-model-adapter/-/active-model-adapter-1.13.4.tgz
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/fguillen/Development/Temp/borrowers/npm-debug.log
```

Looks like is a [known bug](https://github.com/npm/npm/issues/8979), changing the version to "1.13.5" fix the problem.
